### PR TITLE
Add deterministic thread lookup

### DIFF
--- a/src/internal/messaging/messaging-facade.ts
+++ b/src/internal/messaging/messaging-facade.ts
@@ -54,10 +54,18 @@ export class MessagingFacade implements Messaging {
   }
 
   async find(query: FindThreadQuery): Promise<Thread | null> {
+    if ('id' in query && query.id.backend) {
+      const { messaging } = this.lookUpMessagingBackend(query.id.backend);
+      return messaging.find(query);
+    }
     for (const { messaging } of this.messagingBackends) {
-      const thread = await messaging.find(query);
-      if (thread) {
-        return thread;
+      try {
+        const thread = await messaging.find(query);
+        if (thread) {
+          return thread;
+        }
+      } catch (e) {
+        console.error(e);
       }
     }
     return null;

--- a/src/messaging/messaging.interface.ts
+++ b/src/messaging/messaging.interface.ts
@@ -27,19 +27,24 @@ export interface CreateThreadCommand {
 }
 
 export type FindThreadQuery =
-  | FindThreadByAddressQuery
+  | FindThreadByIdQuery
   | FindThreadByOtherMemberQuery;
 
-export interface FindThreadByAddressQuery {
-  address: PublicKey;
+export interface FindThreadByIdQuery {
+  id: ThreadId;
 }
 
 export interface FindThreadByOtherMemberQuery {
   otherMembers: PublicKey[];
 }
 
-export interface Thread {
+export interface ThreadId {
   address: PublicKey;
+  backend?: Backend;
+}
+
+export interface Thread {
+  id: ThreadId;
   me: ThreadMember;
   otherMembers: ThreadMember[];
   encryptionEnabled: boolean;


### PR DESCRIPTION
Guys, please take a look

**This solves the following scenario:**

Given sdk backends configuration: `[SOLANA, DIALECT_CLOUD]` and solana is not available
When thread list is fetched using `findAll()` is contains only threads from `DIALECT_CLOUD` backend,  and then thead `find()` is called providing `thread.address` for some of the threads

**Actual behaviour:**

Then thread cannot be found and error is thrown, since solana has higher priority in backends configuration and solana is not available

**Actual behaviour:**

Then thread should be found

FYI @kevindingens 
