### PR TITLE
Support multiple subjects in encryption and auth stores

### DIFF
--- a/src/auth/token-store.ts
+++ b/src/auth/token-store.ts
@@ -1,7 +1,13 @@
 import type { Token } from '@auth/auth.interface';
+import type { PublicKey } from '@solana/web3.js';
+import {
+  InMemoryTokenStore,
+  LocalStorageTokenStore,
+  SessionStorageTokenStore,
+} from '@auth/internal/token-store';
 
 export abstract class TokenStore {
-  abstract get(): Token | null;
+  abstract get(subject: PublicKey): Token | null;
 
   abstract save(token: Token): Token;
 
@@ -15,50 +21,5 @@ export abstract class TokenStore {
 
   static createLocalStorage(): TokenStore {
     return new LocalStorageTokenStore();
-  }
-}
-
-export class InMemoryTokenStore extends TokenStore {
-  private token: Token | null = null;
-
-  get(): Token | null {
-    return this.token;
-  }
-
-  save(token: Token): Token {
-    this.token = token;
-    return this.token;
-  }
-}
-
-const storageTokenKey = 'dialect-auth-token';
-
-export class SessionStorageTokenStore implements TokenStore {
-  get(): Token | null {
-    const token = sessionStorage.getItem(storageTokenKey);
-    if (!token) {
-      return null;
-    }
-    return JSON.parse(token) as Token;
-  }
-
-  save(token: Token): Token {
-    sessionStorage.setItem(storageTokenKey, JSON.stringify(token));
-    return token;
-  }
-}
-
-export class LocalStorageTokenStore implements TokenStore {
-  get(): Token | null {
-    const token = localStorage.getItem(storageTokenKey);
-    if (!token) {
-      return null;
-    }
-    return JSON.parse(token) as Token;
-  }
-
-  save(token: Token): Token {
-    localStorage.setItem(storageTokenKey, JSON.stringify(token));
-    return token;
   }
 }

--- a/src/encryption/encryption-keys-store.ts
+++ b/src/encryption/encryption-keys-store.ts
@@ -1,9 +1,15 @@
 import type { DiffeHellmanKeys } from '@encryption/encryption.interface';
+import {
+  InmemoryEncryptionKeysStore,
+  LocalStorageEncryptionKeysStore,
+  SessionStorageEncryptionKeysStore,
+} from '@encryption/internal/encryption-keys-store';
+import type { PublicKey } from '@solana/web3.js';
 
 export abstract class EncryptionKeysStore {
-  abstract get(): DiffeHellmanKeys | null;
+  abstract get(subject: PublicKey): DiffeHellmanKeys | null;
 
-  abstract save(keys: DiffeHellmanKeys): DiffeHellmanKeys;
+  abstract save(subject: PublicKey, keys: DiffeHellmanKeys): DiffeHellmanKeys;
 
   static createInMemory(): EncryptionKeysStore {
     return new InmemoryEncryptionKeysStore();
@@ -15,50 +21,5 @@ export abstract class EncryptionKeysStore {
 
   static createLocalStorage(): EncryptionKeysStore {
     return new LocalStorageEncryptionKeysStore();
-  }
-}
-
-export class InmemoryEncryptionKeysStore extends EncryptionKeysStore {
-  private keys: DiffeHellmanKeys | null = null;
-
-  get(): DiffeHellmanKeys | null {
-    return this.keys;
-  }
-
-  save(keys: DiffeHellmanKeys): DiffeHellmanKeys {
-    this.keys = keys;
-    return this.keys;
-  }
-}
-
-const storageEncryptionKeysKey = 'dialect-encryption-keys';
-
-export class SessionStorageEncryptionKeysStore implements EncryptionKeysStore {
-  get(): DiffeHellmanKeys | null {
-    const keys = sessionStorage.getItem(storageEncryptionKeysKey);
-    if (!keys) {
-      return null;
-    }
-    return JSON.parse(keys) as DiffeHellmanKeys;
-  }
-
-  save(keys: DiffeHellmanKeys): DiffeHellmanKeys {
-    sessionStorage.setItem(storageEncryptionKeysKey, JSON.stringify(keys));
-    return keys;
-  }
-}
-
-export class LocalStorageEncryptionKeysStore implements EncryptionKeysStore {
-  get(): DiffeHellmanKeys | null {
-    const keys = localStorage.getItem(storageEncryptionKeysKey);
-    if (!keys) {
-      return null;
-    }
-    return JSON.parse(keys) as DiffeHellmanKeys;
-  }
-
-  save(keys: DiffeHellmanKeys): DiffeHellmanKeys {
-    localStorage.setItem(storageEncryptionKeysKey, JSON.stringify(keys));
-    return keys;
   }
 }

--- a/src/internal/auth/token-store.ts
+++ b/src/internal/auth/token-store.ts
@@ -1,0 +1,58 @@
+import { TokenStore } from '@auth/token-store';
+import type { Token } from '@auth/auth.interface';
+import type { PublicKey } from '@solana/web3.js';
+
+export class InMemoryTokenStore extends TokenStore {
+  private tokens: Map<string, Token> = new Map<string, Token>();
+
+  get(subject: PublicKey): Token | null {
+    return this.tokens.get(subject.toBase58()) ?? null;
+  }
+
+  save(token: Token): Token {
+    this.tokens.set(token.body.sub, token);
+    return token;
+  }
+}
+
+export class SessionStorageTokenStore implements TokenStore {
+  get(subject: PublicKey): Token | null {
+    const token = sessionStorage.getItem(createStorageKey(subject.toBase58()));
+    if (!token) {
+      return null;
+    }
+    return JSON.parse(token) as Token;
+  }
+
+  save(token: Token): Token {
+    sessionStorage.setItem(
+      createStorageKey(token.body.sub),
+      JSON.stringify(token),
+    );
+    return token;
+  }
+}
+
+export class LocalStorageTokenStore implements TokenStore {
+  get(subject: PublicKey): Token | null {
+    const token = localStorage.getItem(createStorageKey(subject.toBase58()));
+    if (!token) {
+      return null;
+    }
+    return JSON.parse(token) as Token;
+  }
+
+  save(token: Token): Token {
+    localStorage.setItem(
+      createStorageKey(token.body.sub),
+      JSON.stringify(token),
+    );
+    return token;
+  }
+}
+
+const storageTokenKeyPrefix = 'dialect-auth-token-';
+
+function createStorageKey(subject: string) {
+  return `${storageTokenKeyPrefix}-${subject}`;
+}

--- a/src/internal/encryption/encryption-keys-store.ts
+++ b/src/internal/encryption/encryption-keys-store.ts
@@ -1,0 +1,61 @@
+import type { DiffeHellmanKeys } from '@encryption/encryption.interface';
+import { EncryptionKeysStore } from '@encryption/encryption-keys-store';
+import type { PublicKey } from '@solana/web3.js';
+
+export class InmemoryEncryptionKeysStore extends EncryptionKeysStore {
+  private keys: Map<string, DiffeHellmanKeys> = new Map<
+    string,
+    DiffeHellmanKeys
+  >();
+
+  get(subject: PublicKey): DiffeHellmanKeys | null {
+    return this.keys.get(subject.toBase58()) ?? null;
+  }
+
+  save(subject: PublicKey, keys: DiffeHellmanKeys): DiffeHellmanKeys {
+    this.keys.set(subject.toBase58(), keys);
+    return keys;
+  }
+}
+
+export class SessionStorageEncryptionKeysStore implements EncryptionKeysStore {
+  get(subject: PublicKey): DiffeHellmanKeys | null {
+    const keys = sessionStorage.getItem(createStorageKey(subject.toBase58()));
+    if (!keys) {
+      return null;
+    }
+    return JSON.parse(keys) as DiffeHellmanKeys;
+  }
+
+  save(subject: PublicKey, keys: DiffeHellmanKeys): DiffeHellmanKeys {
+    sessionStorage.setItem(
+      createStorageKey(subject.toBase58()),
+      JSON.stringify(keys),
+    );
+    return keys;
+  }
+}
+
+export class LocalStorageEncryptionKeysStore implements EncryptionKeysStore {
+  get(subject: PublicKey): DiffeHellmanKeys | null {
+    const keys = localStorage.getItem(createStorageKey(subject.toBase58()));
+    if (!keys) {
+      return null;
+    }
+    return JSON.parse(keys) as DiffeHellmanKeys;
+  }
+
+  save(subject: PublicKey, keys: DiffeHellmanKeys): DiffeHellmanKeys {
+    localStorage.setItem(
+      createStorageKey(subject.toBase58()),
+      JSON.stringify(keys),
+    );
+    return keys;
+  }
+}
+
+const storageEncryptionKeysPrefix = 'dialect-encryption-keys-';
+
+function createStorageKey(subject: string) {
+  return `${storageEncryptionKeysPrefix}-${subject}`;
+}

--- a/src/sdk/sdk.interface.ts
+++ b/src/sdk/sdk.interface.ts
@@ -36,13 +36,18 @@ export interface SolanaInfo {
 }
 
 export type Environment = 'production' | 'development' | 'local-development';
+export type TokenStoreType = 'in-memory' | 'session-storage' | 'local-storage';
+export type EncryptionKeysStoreType =
+  | 'in-memory'
+  | 'session-storage'
+  | 'local-storage';
 
 export interface ConfigProps {
   environment?: Environment;
   wallet: DialectWalletAdapter;
   solana?: SolanaConfigProps;
   dialectCloud?: DialectCloudConfigProps;
-  encryptionKeysStore?: EncryptionKeysStore;
+  encryptionKeysStore?: EncryptionKeysStoreType | EncryptionKeysStore;
   backends?: Backend[];
 }
 
@@ -55,7 +60,7 @@ export interface SolanaConfigProps {
 export interface DialectCloudConfigProps {
   environment?: DialectCloudEnvironment;
   url?: string;
-  tokenStore?: TokenStore;
+  tokenStore?: TokenStoreType | TokenStore;
 }
 
 export type SolanaNetwork = 'mainnet-beta' | 'devnet' | 'localnet';


### PR DESCRIPTION
1) Each wallet (subject) keys are stored using separate key
2) Added high level configuration for stores

<img width="401" alt="image" src="https://user-images.githubusercontent.com/7888282/175616405-9639a124-a58a-40b6-83d3-54b796ffec3e.png">

Used-defined also still supported
<img width="550" alt="image" src="https://user-images.githubusercontent.com/7888282/175616471-9e6b0dad-b8ba-41fa-95df-26eb0de80d90.png">
