### PR TITLE
[CORE-171] Unnecessary identity error logs

### DIFF
--- a/packages/identity-cardinal/src/identity-cardinal-twitter.error.ts
+++ b/packages/identity-cardinal/src/identity-cardinal-twitter.error.ts
@@ -1,0 +1,9 @@
+import { IdentityError } from '@dialectlabs/sdk';
+
+export class CardinalIdentityError extends IdentityError {
+  static ignoreMatcher = ['Account does not exist']; // warning, not error
+
+  constructor(msg?: string) {
+    super(CardinalIdentityError.name, 'Cardinal Identity Error', msg);
+  }
+}

--- a/packages/identity-civic/CHANGELOG.md
+++ b/packages/identity-civic/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+## [UNRELEASED]
+
+## [0.0.4] - 2022-09-27
+
+- refactor: identity resolve handled in try catch and unnecessary error caught

--- a/packages/identity-civic/package.json
+++ b/packages/identity-civic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dialectlabs/identity-civic",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Civic Identity Resolver",
   "repository": "git@github.com:dialectlabs/sdk.git",
   "author": "Kevin Colgan",

--- a/packages/identity-civic/src/identity-civic.error.ts
+++ b/packages/identity-civic/src/identity-civic.error.ts
@@ -1,0 +1,9 @@
+import { IdentityError } from '@dialectlabs/sdk';
+
+export class CivicIdentityError extends IdentityError {
+  static ignoreMatcher = ['Unsupported storage location']; // warning, not error
+
+  constructor(msg?: string) {
+    super(CivicIdentityError.name, 'Civic Identity Error', msg);
+  }
+}

--- a/packages/identity-civic/src/identity-civic.ts
+++ b/packages/identity-civic/src/identity-civic.ts
@@ -1,6 +1,6 @@
 import { CivicProfile, ProfileResult } from '@civic/profile';
 import type { Identity, IdentityResolver } from '@dialectlabs/sdk';
-import { CivicIdentityError } from '@dialectlabs/sdk';
+import { CivicIdentityError } from './identity-civic.error';
 import type { Connection } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 

--- a/packages/identity-civic/src/identity-civic.ts
+++ b/packages/identity-civic/src/identity-civic.ts
@@ -1,5 +1,6 @@
 import { CivicProfile, ProfileResult } from '@civic/profile';
 import type { Identity, IdentityResolver } from '@dialectlabs/sdk';
+import { CivicIdentityError } from '@dialectlabs/sdk';
 import type { Connection } from '@solana/web3.js';
 import { PublicKey } from '@solana/web3.js';
 
@@ -26,13 +27,20 @@ export class CivicIdentityResolver implements IdentityResolver {
   }
 
   async resolve(publicKey: PublicKey): Promise<Identity | null> {
-    const profile = await CivicProfile.get(publicKey.toBase58(), {
-      solana: { connection: this.connection },
-    });
-    if (!profile.name) {
-      return null;
+    try {
+      const profile = await CivicProfile.get(publicKey.toBase58(), {
+        solana: { connection: this.connection },
+      });
+      if (!profile.name) {
+        return null;
+      }
+      return civicProfileToDialectIdentity(profile);
+    } catch (e: any) {
+      if (!CivicIdentityError.ignoreMatcher.some((it) => e.message.match(it))) {
+        throw new CivicIdentityError(e.message);
+      }
     }
-    return civicProfileToDialectIdentity(profile);
+    return null;
   }
 
   async resolveReverse(_rawDomainName: string): Promise<Identity | null> {

--- a/packages/identity-sns/CHANGELOG.md
+++ b/packages/identity-sns/CHANGELOG.md
@@ -1,0 +1,7 @@
+# CHANGELOG
+
+## [UNRELEASED]
+
+## [0.0.3] - 2022-09-27
+
+- refactor: identity resolve handled in try catch and unnecessary error caught

--- a/packages/identity-sns/jest.config.ts
+++ b/packages/identity-sns/jest.config.ts
@@ -5,6 +5,8 @@ const config: Config.InitialOptions = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
+  testRegex: '(.*\\.spec)\\.(jsx?|tsx?)$',
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testTimeout: 60000,
   testRunner: 'jasmine2',
 };

--- a/packages/identity-sns/package.json
+++ b/packages/identity-sns/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dialectlabs/identity-sns",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "repository": "git@github.com:dialectlabs/sdk.git",
   "author": "dialectlabs",
   "license": "Apache-2.0",

--- a/packages/identity-sns/src/identity-sns.error.ts
+++ b/packages/identity-sns/src/identity-sns.error.ts
@@ -1,0 +1,9 @@
+import { IdentityError } from '@dialectlabs/sdk';
+
+export class SNSIdentityError extends IdentityError {
+  static ignoreMatcher = ['Favourite domain not found']; // warning, not error
+
+  constructor(msg?: string) {
+    super(SNSIdentityError.name, 'SNS Identity Error', msg);
+  }
+}

--- a/packages/identity-sns/src/identity-sns.ts
+++ b/packages/identity-sns/src/identity-sns.ts
@@ -4,7 +4,7 @@ import {
   NameRegistryState,
 } from '@bonfida/spl-name-service';
 import type { Identity, IdentityResolver } from '@dialectlabs/sdk';
-import { SNSIdentityError } from '@dialectlabs/sdk';
+import { SNSIdentityError } from './identity-sns.error';
 import type { Connection, PublicKey } from '@solana/web3.js';
 
 export class SNSIdentityResolver implements IdentityResolver {

--- a/packages/identity-sns/src/identity-sns.ts
+++ b/packages/identity-sns/src/identity-sns.ts
@@ -4,6 +4,7 @@ import {
   NameRegistryState,
 } from '@bonfida/spl-name-service';
 import type { Identity, IdentityResolver } from '@dialectlabs/sdk';
+import { SNSIdentityError } from '@dialectlabs/sdk';
 import type { Connection, PublicKey } from '@solana/web3.js';
 
 export class SNSIdentityResolver implements IdentityResolver {
@@ -13,15 +14,22 @@ export class SNSIdentityResolver implements IdentityResolver {
   }
 
   async resolve(publicKey: PublicKey): Promise<Identity | null> {
-    const res = await getFavoriteDomain(this.connection, publicKey);
-    return {
-      name: res.reverse,
-      publicKey,
-      type: this.type,
-      additionals: {
-        displayName: `${res.reverse}.sol`,
-      },
-    };
+    try {
+      const res = await getFavoriteDomain(this.connection, publicKey);
+      return {
+        name: res.reverse,
+        publicKey,
+        type: this.type,
+        additionals: {
+          displayName: `${res.reverse}.sol`,
+        },
+      };
+    } catch (e: any) {
+      if (!SNSIdentityError.ignoreMatcher.some((it) => e.message.match(it))) {
+        throw new SNSIdentityError(e.message);
+      }
+    }
+    return null;
   }
 
   async resolveReverse(rawDomainName: string): Promise<Identity | null> {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED]
 
+## [0.12.0] - 2022-09-27
+
+- feature: error models for identities created
+ 
 ## [0.11.0] - 2022-09-20
 
 - feature: add website, heroUrl and index fields for dapp model

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dialectlabs/sdk",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "repository": "git@github.com:dialectlabs/sdk.git",
   "author": "dialectlabs",
   "license": "Apache-2.0",

--- a/packages/sdk/src/sdk/errors.ts
+++ b/packages/sdk/src/sdk/errors.ts
@@ -140,3 +140,29 @@ export class ThreadAlreadyExistsError extends MessagingError {
     );
   }
 }
+
+export abstract class IdentityError extends DialectSdkError {}
+
+export class SNSIdentityError extends IdentityError {
+  static ignoreMatcher = ['Favourite domain not found']; // warning, not error
+
+  constructor(msg?: string) {
+    super(SNSIdentityError.name, 'SNS Identity Error', msg);
+  }
+}
+
+export class CardinalIdentityError extends IdentityError {
+  static ignoreMatcher = ['Account does not exist']; // warning, not error
+
+  constructor(msg?: string) {
+    super(CardinalIdentityError.name, 'Cardinal Identity Error', msg);
+  }
+}
+
+export class CivicIdentityError extends IdentityError {
+  static ignoreMatcher = ['unsupported storage location']; // warning, not error
+
+  constructor(msg?: string) {
+    super(CivicIdentityError.name, 'Civic Identity Error', msg);
+  }
+}

--- a/packages/sdk/src/sdk/errors.ts
+++ b/packages/sdk/src/sdk/errors.ts
@@ -142,27 +142,3 @@ export class ThreadAlreadyExistsError extends MessagingError {
 }
 
 export abstract class IdentityError extends DialectSdkError {}
-
-export class SNSIdentityError extends IdentityError {
-  static ignoreMatcher = ['Favourite domain not found']; // warning, not error
-
-  constructor(msg?: string) {
-    super(SNSIdentityError.name, 'SNS Identity Error', msg);
-  }
-}
-
-export class CardinalIdentityError extends IdentityError {
-  static ignoreMatcher = ['Account does not exist']; // warning, not error
-
-  constructor(msg?: string) {
-    super(CardinalIdentityError.name, 'Cardinal Identity Error', msg);
-  }
-}
-
-export class CivicIdentityError extends IdentityError {
-  static ignoreMatcher = ['unsupported storage location']; // warning, not error
-
-  constructor(msg?: string) {
-    super(CivicIdentityError.name, 'Civic Identity Error', msg);
-  }
-}


### PR DESCRIPTION
There are identity errors even they must be warnings. They are caught and ignored. One of them is not caught because third party library just console.log the error instead of throwing. I created an issue for this https://github.com/cardinal-labs/cardinal-namespaces/issues/182

