### PR TITLE
@cardinal/namespaces library version update

### DIFF
--- a/packages/identity-cardinal/package.json
+++ b/packages/identity-cardinal/package.json
@@ -26,6 +26,6 @@
     "@solana/web3.js": "1.x"
   },
   "dependencies": {
-    "@cardinal/namespaces": "^4.1.55"
+    "@cardinal/namespaces": "^4.1.57"
   }
 }


### PR DESCRIPTION
![Screen Shot 2022-10-03 at 10 53 57](https://user-images.githubusercontent.com/45829113/193530128-c0f13166-05a0-4511-ab08-e4eaad103656.png)

There was an unnecessary string error log with this third party library and I created an issue to their repos. Now the unnecessary log is removed. 