### PR TITLE
fix(IN-84): users are unable to auth with ledger

### DIFF
--- a/packages/blockchain-sdk-solana/src/auth/tx/solana-tx-token-signer.ts
+++ b/packages/blockchain-sdk-solana/src/auth/tx/solana-tx-token-signer.ts
@@ -40,9 +40,7 @@ export class DialectWalletAdapterSolanaTxTokenSigner extends SolanaTxTokenSigner
 
   async sign(payload: Uint8Array): Promise<TokenSignerResult> {
     const tx = new Transaction();
-    const subjectPublicKey = new SolanaPublicKey(
-      this.subjectPublicKey.toString(),
-    );
+    const subjectPublicKey = new SolanaPublicKey(this.subject);
     tx.add(
       new TransactionInstruction({
         keys: [

--- a/packages/blockchain-sdk-solana/src/auth/tx/solana-tx-token-validator.ts
+++ b/packages/blockchain-sdk-solana/src/auth/tx/solana-tx-token-validator.ts
@@ -17,6 +17,9 @@ export class SolanaTxTokenValidator extends TokenValidator {
   }
 
   override performExtraValidation(token: Token): boolean {
+    if (!token.body.sub_jwk) {
+      return true;
+    }
     return token.body.sub === token.body.sub_jwk;
   }
 }

--- a/packages/blockchain-sdk-solana/tests/auth/ed25519/solana-ed25519-authentication-facade-factory.spec.ts
+++ b/packages/blockchain-sdk-solana/tests/auth/ed25519/solana-ed25519-authentication-facade-factory.spec.ts
@@ -105,7 +105,22 @@ describe('solana ed25519 token tests', () => {
     expect(isParsedTokenValid).toBeFalsy();
   });
 
-  test('subject and subject public must be same if defined', async () => {
+  test('subject and subject public are same', async () => {
+    // when
+    const signer = new DialectWalletAdapterSolanaEd25519TokenSigner(wallet);
+    authenticationFacade = new SolanaEd25519AuthenticationFacadeFactory(
+      signer,
+    ).get();
+    // when
+    const token = await authenticationFacade.generateToken(
+      Duration.fromObject({ seconds: 100 }),
+    );
+    // then
+    expect(token.body.sub).toBe(wallet.publicKey.toString());
+    expect(token.body.sub_jwk).toBe(wallet.publicKey.toString());
+  });
+
+  test('subject and subject public cannot be different if defined', async () => {
     // when
     const subjectPublicKey = new Ed25519PublicKey(
       generateEd25519Keypair().publicKey,


### PR DESCRIPTION
Add test for solana-tx backward compatibility and make sub_jwk claim optional