### PR TITLE
feature(IN-87) add read marking for dapp messages feed

### DIFF
--- a/packages/blockchain-sdk-solana/src/messaging/solana-messaging.ts
+++ b/packages/blockchain-sdk-solana/src/messaging/solana-messaging.ts
@@ -270,7 +270,7 @@ export class SolanaThread implements Thread {
     );
   }
 
-  setLastReadMessageTime(time: Date): Promise<void> {
+  markAsRead(): Promise<void> {
     return Promise.resolve(undefined);
   }
 }

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [UNRELEASED]
 
+## [1.1.0] - 2022-10-05
+
+- feature: add read/unread messages api for dapp notification feed
+
 ## [1.0.0] - 2022-10-05
 
 - stable release

--- a/packages/sdk/src/dialect-cloud-api/data-service-dialects-api.ts
+++ b/packages/sdk/src/dialect-cloud-api/data-service-dialects-api.ts
@@ -25,10 +25,12 @@ export interface DataServiceDialectsApi {
 
   findSummaryAll(query: FindDialectsSummaryDto): Promise<DialectsSummaryDto>;
 
-  patchMember(
-    dialectPublicKey: string,
-    command: PatchMemberCommandDto,
-  ): Promise<MemberDto>;
+  markAsRead(dialectPublicKey: string): Promise<void>;
+
+  // patchMember(
+  //   dialectPublicKey: string,
+  //   command: PatchMemberCommandDto,
+  // ): Promise<MemberDto>;
 }
 
 export class DataServiceDialectsApiClient implements DataServiceDialectsApi {
@@ -37,16 +39,13 @@ export class DataServiceDialectsApiClient implements DataServiceDialectsApi {
     private readonly tokenProvider: TokenProvider,
   ) {}
 
-  async patchMember(
-    dialectPublicKey: string,
-    command: PatchMemberCommandDto,
-  ): Promise<MemberDto> {
+  async markAsRead(dialectPublicKey: string): Promise<void> {
     const token = await this.tokenProvider.get();
     return withReThrowingDataServiceError(
       axios
-        .patch<MemberDto>(
-          `${this.baseUrl}/api/v1/dialects/${dialectPublicKey}/members/me`,
-          command,
+        .post<void>(
+          `${this.baseUrl}/api/v1/dialects/${dialectPublicKey}/markAsRead`,
+          {},
           {
             headers: createHeaders(token),
           },
@@ -54,6 +53,24 @@ export class DataServiceDialectsApiClient implements DataServiceDialectsApi {
         .then((it) => it.data),
     );
   }
+
+  // async patchMember(
+  //   dialectPublicKey: string,
+  //   command: PatchMemberCommandDto,
+  // ): Promise<MemberDto> {
+  //   const token = await this.tokenProvider.get();
+  //   return withReThrowingDataServiceError(
+  //     axios
+  //       .patch<MemberDto>(
+  //         `${this.baseUrl}/api/v1/dialects/${dialectPublicKey}/members/me`,
+  //         command,
+  //         {
+  //           headers: createHeaders(token),
+  //         },
+  //       )
+  //       .then((it) => it.data),
+  //   );
+  // }
 
   async create(command: CreateDialectCommand): Promise<DialectAccountDto> {
     const token = await this.tokenProvider.get();

--- a/packages/sdk/src/dialect-cloud-api/data-service-wallet-messages-api.ts
+++ b/packages/sdk/src/dialect-cloud-api/data-service-wallet-messages-api.ts
@@ -1,5 +1,8 @@
 import type { TokenProvider } from '../auth/token-provider';
-import type { MessageDto } from './data-service-dialects-api';
+import type {
+  DialectsSummaryDto,
+  MessageDto,
+} from './data-service-dialects-api';
 import {
   createHeaders,
   withReThrowingDataServiceError,
@@ -10,11 +13,31 @@ export interface DataServiceWalletMessagesApi {
   findAllDappMessages(
     query?: FindWalletMessagesQueryDto,
   ): Promise<MessageDto[]>;
+
+  dappMessagesSummary(
+    query?: FindDappMessagesSummaryQueryDto,
+  ): Promise<DialectsSummaryDto>;
+
+  markAllDappMessagesAsRead(
+    command?: MarkDappMessagesAsReadCommandDto,
+  ): Promise<void>;
+}
+
+export interface FindDappMessagesSummaryQueryDto {
+  readonly dappVerified?: boolean;
+}
+
+export interface MarkDappMessagesAsReadCommandDto {
+  readonly dappVerified?: boolean;
 }
 
 export interface FindWalletMessagesQueryDto {
   readonly skip?: number;
   readonly take?: number;
+  readonly dappVerified?: boolean;
+}
+
+export interface MarkDappMessagesAsReadCommandDto {
   readonly dappVerified?: boolean;
 }
 
@@ -36,6 +59,40 @@ export class DataServiceWalletMessagesApiClient
           headers: createHeaders(token),
           ...(query && { params: query }),
         })
+        .then((it) => it.data),
+    );
+  }
+
+  async dappMessagesSummary(
+    query?: FindDappMessagesSummaryQueryDto,
+  ): Promise<DialectsSummaryDto> {
+    const token = await this.tokenProvider.get();
+    return withReThrowingDataServiceError(
+      axios
+        .get<DialectsSummaryDto>(
+          `${this.baseUrl}/api/v1/wallets/me/dappMessages/summary`,
+          {
+            headers: createHeaders(token),
+            ...(query && { params: query }),
+          },
+        )
+        .then((it) => it.data),
+    );
+  }
+
+  async markAllDappMessagesAsRead(
+    command?: MarkDappMessagesAsReadCommandDto,
+  ): Promise<void> {
+    const token = await this.tokenProvider.get();
+    return withReThrowingDataServiceError(
+      axios
+        .post<void>(
+          `${this.baseUrl}/api/v1/wallets/me/dappMessages/markAsRead`,
+          command,
+          {
+            headers: createHeaders(token),
+          },
+        )
         .then((it) => it.data),
     );
   }

--- a/packages/sdk/src/dialect-cloud-api/data-service-wallet-messages-api.ts
+++ b/packages/sdk/src/dialect-cloud-api/data-service-wallet-messages-api.ts
@@ -27,10 +27,6 @@ export interface FindDappMessagesSummaryQueryDto {
   readonly dappVerified?: boolean;
 }
 
-export interface MarkDappMessagesAsReadCommandDto {
-  readonly dappVerified?: boolean;
-}
-
 export interface FindWalletMessagesQueryDto {
   readonly skip?: number;
   readonly take?: number;

--- a/packages/sdk/src/internal/messaging/data-service-messaging.ts
+++ b/packages/sdk/src/internal/messaging/data-service-messaging.ts
@@ -303,7 +303,7 @@ export class DataServiceThread implements Thread {
     if (this.encryptionEnabledButCannotBeUsed()) {
       return [];
     }
-    return dialect.messages.map((it) => ({
+    const messages = dialect.messages.map((it) => ({
       author:
         it.owner === this.me.address.toString()
           ? this.me
@@ -312,6 +312,8 @@ export class DataServiceThread implements Thread {
       text: this.textSerde.deserialize(new Uint8Array(it.text)),
       deduplicationId: it.deduplicationId,
     }));
+    this.lastMessage = messages[0] ?? null;
+    return messages;
   }
 
   async send(command: SendMessageCommand): Promise<void> {
@@ -329,11 +331,9 @@ export class DataServiceThread implements Thread {
     );
   }
 
-  async setLastReadMessageTime(time: Date): Promise<void> {
+  async markAsRead(): Promise<void> {
     await withErrorParsing(
-      this.dataServiceDialectsApi.patchMember(this.id.address.toString(), {
-        lastReadMessageTimestamp: time.getTime(),
-      }),
+      this.dataServiceDialectsApi.markAsRead(this.id.address.toString()),
     );
   }
 

--- a/packages/sdk/src/internal/wallet/data-service-wallets.ts
+++ b/packages/sdk/src/internal/wallet/data-service-wallets.ts
@@ -14,7 +14,9 @@ import type {
   FindDappAddressesQuery,
   FindDappAddressQuery,
   FindDappMessageQuery,
+  FindDappMessagesSummaryQuery,
   FindNotificationSubscriptionQuery,
+  MarkDappMessagesAsReadCommand,
   PartialUpdateAddressCommand,
   PartialUpdateDappAddressCommand,
   ResendVerificationCodeCommand,
@@ -45,6 +47,7 @@ import { withErrorParsing } from '../../dialect-cloud-api/data-service-errors';
 import type { AccountAddress } from '../../auth/auth.interface';
 import type { TextSerde } from '../../messaging/text-serde';
 import { UnencryptedTextSerde } from '../../messaging/text-serde';
+import type { ThreadsGeneralSummary } from '../../messaging/messaging.interface';
 
 export class DataServiceWallets implements Wallets {
   addresses: WalletAddresses;
@@ -206,6 +209,29 @@ export class DataServiceWalletMessages implements WalletMessages {
       timestamp: new Date(it.timestamp),
       text: this.textSerde.deserialize(new Uint8Array(it.text)),
     }));
+  }
+
+  async dappMessagesSummary(
+    query?: FindDappMessagesSummaryQuery,
+  ): Promise<ThreadsGeneralSummary> {
+    const summaryDto = await withErrorParsing(
+      this.api.dappMessagesSummary({
+        dappVerified: query?.dappVerified,
+      }),
+    );
+    return {
+      unreadMessagesCount: summaryDto.unreadMessagesCount,
+    };
+  }
+
+  async markAllDappMessagesAsRead(
+    command?: MarkDappMessagesAsReadCommand,
+  ): Promise<void> {
+    await withErrorParsing(
+      this.api.markAllDappMessagesAsRead({
+        dappVerified: command?.dappVerified,
+      }),
+    );
   }
 }
 

--- a/packages/sdk/src/messaging/messaging.interface.ts
+++ b/packages/sdk/src/messaging/messaging.interface.ts
@@ -108,7 +108,7 @@ export interface Thread {
 
   delete(): Promise<void>;
 
-  setLastReadMessageTime(time: Date): Promise<void>;
+  markAsRead(): Promise<void>;
 }
 
 export interface ThreadMember {

--- a/packages/sdk/src/wallet/wallet.interface.ts
+++ b/packages/sdk/src/wallet/wallet.interface.ts
@@ -4,6 +4,7 @@ import type {
   DappAddress,
 } from '../address/addresses.interface';
 import type { AccountAddress } from '../auth/auth.interface';
+import type { ThreadsGeneralSummary } from '../messaging/messaging.interface';
 
 export interface Wallets {
   readonly address: AccountAddress;
@@ -97,8 +98,22 @@ export interface DeleteDappAddressCommand {
   readonly dappAddressId: string;
 }
 
+export interface FindDappMessagesSummaryQuery {
+  readonly dappVerified?: boolean;
+}
+
+export interface MarkDappMessagesAsReadCommand {
+  readonly dappVerified?: boolean;
+}
+
 export interface WalletMessages {
   findAllFromDapps(query?: FindDappMessageQuery): Promise<DappMessage[]>;
+  dappMessagesSummary(
+    query?: FindDappMessagesSummaryQuery,
+  ): Promise<ThreadsGeneralSummary>;
+  markAllDappMessagesAsRead(
+    command?: MarkDappMessagesAsReadCommand,
+  ): Promise<void>;
 }
 
 export interface DappMessage {
@@ -110,6 +125,10 @@ export interface DappMessage {
 export interface FindDappMessageQuery {
   readonly skip?: number;
   readonly take?: number;
+  readonly dappVerified?: boolean;
+}
+
+export interface MarkDappMessagesAsReadCommand {
   readonly dappVerified?: boolean;
 }
 

--- a/packages/sdk/src/wallet/wallet.interface.ts
+++ b/packages/sdk/src/wallet/wallet.interface.ts
@@ -102,10 +102,6 @@ export interface FindDappMessagesSummaryQuery {
   readonly dappVerified?: boolean;
 }
 
-export interface MarkDappMessagesAsReadCommand {
-  readonly dappVerified?: boolean;
-}
-
 export interface WalletMessages {
   findAllFromDapps(query?: FindDappMessageQuery): Promise<DappMessage[]>;
   dappMessagesSummary(

--- a/packages/sdk/tests/e2e/marking-dapp-messages-as-read.spec.ts
+++ b/packages/sdk/tests/e2e/marking-dapp-messages-as-read.spec.ts
@@ -1,0 +1,59 @@
+import {
+  NodeDialectSolanaWalletAdapter,
+  SolanaSdkFactory,
+} from '@dialectlabs/blockchain-sdk-solana';
+import { Dialect, ThreadMemberScope } from '@dialectlabs/sdk';
+
+describe('Marking dapp messages as read test (e2e)', () => {
+  test('can mark message as read', async () => {
+    // given
+    const dappSdk = Dialect.sdk(
+      {
+        environment: 'local-development',
+      },
+      SolanaSdkFactory.create({
+        wallet: NodeDialectSolanaWalletAdapter.create(),
+      }),
+    );
+    const receiverSdk = Dialect.sdk(
+      {
+        environment: 'local-development',
+      },
+      SolanaSdkFactory.create({
+        wallet: NodeDialectSolanaWalletAdapter.create(),
+      }),
+    );
+    await dappSdk.dapps.create({
+      name: 'Marking dapp messages as read test (e2e)',
+    });
+    const thread = await dappSdk.threads.create({
+      encrypted: false,
+      me: {
+        scopes: [ThreadMemberScope.WRITE, ThreadMemberScope.ADMIN],
+      },
+      otherMembers: [
+        {
+          address: receiverSdk.wallet.address,
+          scopes: [ThreadMemberScope.WRITE, ThreadMemberScope.ADMIN],
+        },
+      ],
+    });
+    await thread.send({
+      text: 'Hello from Solana!',
+    });
+    const summary = await receiverSdk.wallet.messages.dappMessagesSummary({
+      dappVerified: false,
+    });
+    expect(summary.unreadMessagesCount).toBe(1);
+    // when
+    await receiverSdk.wallet.messages.markAllDappMessagesAsRead({
+      dappVerified: false,
+    });
+    const summaryAfterMarking =
+      await receiverSdk.wallet.messages.dappMessagesSummary({
+        dappVerified: false,
+      });
+    // then
+    expect(summaryAfterMarking?.unreadMessagesCount).toBe(0);
+  });
+});

--- a/packages/sdk/tests/e2e/marking-thread-messages-as-read.spec.ts
+++ b/packages/sdk/tests/e2e/marking-thread-messages-as-read.spec.ts
@@ -1,0 +1,57 @@
+import {
+  NodeDialectSolanaWalletAdapter,
+  SolanaSdkFactory,
+} from '@dialectlabs/blockchain-sdk-solana';
+import type { Thread } from '@dialectlabs/sdk';
+import { Dialect, ThreadMemberScope } from '@dialectlabs/sdk';
+
+describe('Marking thread messages as read test (e2e)', () => {
+  test('can mark message as read', async () => {
+    // given
+    const senderSdk = Dialect.sdk(
+      {
+        environment: 'local-development',
+      },
+      SolanaSdkFactory.create({
+        wallet: NodeDialectSolanaWalletAdapter.create(),
+      }),
+    );
+    const receiverSdk = Dialect.sdk(
+      {
+        environment: 'local-development',
+      },
+      SolanaSdkFactory.create({
+        wallet: NodeDialectSolanaWalletAdapter.create(),
+      }),
+    );
+    const thread = await senderSdk.threads.create({
+      encrypted: false,
+      me: {
+        scopes: [ThreadMemberScope.WRITE, ThreadMemberScope.ADMIN],
+      },
+      otherMembers: [
+        {
+          address: receiverSdk.wallet.address,
+          scopes: [ThreadMemberScope.WRITE, ThreadMemberScope.ADMIN],
+        },
+      ],
+    });
+    await thread.send({
+      text: 'Hello from Solana!',
+    });
+    const summary = await receiverSdk.threads.findSummary({
+      otherMembers: [senderSdk.wallet.address],
+    });
+    expect(summary?.me?.unreadMessagesCount).toBe(1);
+    // when
+    const receiverThread: Thread = (await receiverSdk.threads.find({
+      id: thread.id,
+    }))!;
+    await receiverThread.markAsRead();
+    const summaryAfterMarking = await receiverSdk.threads.findSummary({
+      otherMembers: [senderSdk.wallet.address],
+    });
+    // then
+    expect(summaryAfterMarking?.me?.unreadMessagesCount).toBe(0);
+  });
+});


### PR DESCRIPTION
1. Add API to get summary in dapp messages feed and mark feed as unread
2. Align thread API with new endpoint for marking entire thread as read

Related PR: https://github.com/dialectlabs/data-service/pull/81