### PR TITLE
fix(CORE-946) token signed multiple times when expired

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -30,7 +30,8 @@
     "@solana/web3.js": "^1.53.0",
     "@types/bs58": "^4.0.1",
     "@types/ed2curve": "^0.2.2",
-    "@types/luxon": "^2.3.2"
+    "@types/luxon": "^2.3.2",
+    "mockdate": "^3.0.5"
   },
   "dependencies": {
     "@stablelib/base64": "^1.0.1",

--- a/packages/sdk/src/auth/token-provider.ts
+++ b/packages/sdk/src/auth/token-provider.ts
@@ -6,7 +6,6 @@ import type { TokenParser } from './token-parser';
 import type { TokenValidator } from './token-validator';
 import type { AuthenticationFacade } from './authentication-facade';
 import type { TokenGenerator } from './token-generator';
-import type { WalletDto } from '../dialect-cloud-api/data-service-dapps-api';
 import type { DataServiceWalletsApiClientV1 } from '../dialect-cloud-api/data-service-wallets-api.v1';
 
 export const DEFAULT_TOKEN_LIFETIME = Duration.fromObject({ days: 1 });
@@ -72,7 +71,6 @@ export class CachedTokenProvider extends TokenProvider {
     const existingToken = this.getCachedToken();
     const subject = this.subject.toString();
     if (existingToken && this.tokenValidator.isValid(existingToken)) {
-      delete this.delegateGetPromises[subject];
       return existingToken;
     }
     const existingDelegatePromise = this.delegateGetPromises[subject];
@@ -82,6 +80,7 @@ export class CachedTokenProvider extends TokenProvider {
 
     const delegatePromise = this.delegate.get().then(async (it) => {
       this.tokenStore.save(this.subject, it.rawValue);
+      delete this.delegateGetPromises[subject];
       const wallet: { publicKey: string } = {
         publicKey: this.subject,
       };

--- a/packages/sdk/src/auth/token-validator.ts
+++ b/packages/sdk/src/auth/token-validator.ts
@@ -24,7 +24,7 @@ export abstract class TokenValidator {
 
   private isExpired(token: Token) {
     const nowUtcSeconds = new Date().getTime() / 1000;
-    const delta = 30;
+    const delta = 10;
     return nowUtcSeconds + delta > token.body.exp;
   }
 }

--- a/packages/sdk/tests/auth/cached-token-provider.spec.ts
+++ b/packages/sdk/tests/auth/cached-token-provider.spec.ts
@@ -1,0 +1,130 @@
+import * as MockDate from 'mockdate';
+import {
+  CachedTokenProvider,
+  DataServiceWalletsApiClientV1,
+  DefaultTokenProvider,
+  Ed25519AuthenticationFacadeFactory,
+  Ed25519TokenSigner,
+  generateEd25519Keypair,
+  TokenStore,
+} from '../../src';
+import { Duration } from 'luxon';
+import type { Token } from '../../lib/types';
+
+jest.mock('./../../src/dialect-cloud-api/data-service-wallets-api.v1');
+
+describe('Cached token provider test', () => {
+  beforeEach(() => {});
+
+  afterEach(() => {
+    MockDate.reset();
+  });
+
+  test(`
+    given 
+      cached token provider decorator is used
+      and no token previously cached
+    when 
+      token is requested multiple times concurrently
+    then 
+      all token requests are succeeded
+      token is generated only once and cached
+      delegate token provider is called only once`, async () => {
+    // given
+    const tokenValidityMinutes = 1;
+    const { cachedTokenProvider, delegateTokenProviderSpy } =
+      createTokenProvider(tokenValidityMinutes);
+    MockDate.set(new Date('1970-01-01T00:00:00.000Z'));
+    expect(delegateTokenProviderSpy).toBeCalledTimes(0);
+    // when
+    const cycles = 3;
+    const concurrentGetsPerCycle = 100;
+    const totalRequests = cycles * concurrentGetsPerCycle;
+    const tokens = await getTokensConcurrently(
+      cachedTokenProvider,
+      cycles,
+      concurrentGetsPerCycle,
+    );
+    // then
+    expect(tokens).toHaveLength(totalRequests);
+    expect(new Set(tokens.map((it) => it.rawValue)).size).toBe(1);
+    expect(delegateTokenProviderSpy).toBeCalledTimes(1);
+  });
+
+  test(`
+    given 
+      cached token provider decorator is used
+      there is a an expired cached token
+    when 
+      token is requested multiple times concurrently
+    then 
+      all token requests are succeeded
+      new token is generated only once and cached
+      delegate token provider is called only once`, async () => {
+    // given
+    const tokenValidityMinutes = 1;
+    const { cachedTokenProvider, delegateTokenProviderSpy } =
+      createTokenProvider(tokenValidityMinutes);
+    MockDate.set(new Date('1970-01-01T00:00:00.000Z'));
+    const tokenBeforeExpiration = await cachedTokenProvider.get();
+    jest.clearAllMocks();
+    expect(delegateTokenProviderSpy).toBeCalledTimes(0);
+    MockDate.set(new Date('1970-01-01T01:00:00.000Z'));
+    // when
+    const cycles = 2;
+    const concurrentGetsPerCycle = 100;
+    const totalRequests = cycles * concurrentGetsPerCycle;
+    const tokens = await getTokensConcurrently(
+      cachedTokenProvider,
+      cycles,
+      concurrentGetsPerCycle,
+    );
+    // then
+    expect(tokens).toHaveLength(totalRequests);
+    expect(new Set(tokens.map((it) => it.rawValue)).size).toBe(1);
+    expect(tokens[0]?.rawValue).not.toBe(tokenBeforeExpiration.rawValue);
+    expect(delegateTokenProviderSpy).toBeCalledTimes(1);
+  });
+
+  function createTokenProvider(tokenValidityMinutes: number) {
+    const keypair = generateEd25519Keypair();
+    const signer = new Ed25519TokenSigner(keypair);
+    const authenticationFacade = new Ed25519AuthenticationFacadeFactory(
+      signer,
+    ).get();
+
+    const defaultTokenProvider = new DefaultTokenProvider(
+      Duration.fromObject({ minutes: tokenValidityMinutes }),
+      authenticationFacade.tokenGenerator,
+    );
+    const cachedTokenProvider = new CachedTokenProvider(
+      defaultTokenProvider,
+      TokenStore.createInMemory(),
+      authenticationFacade.authenticator.parser,
+      authenticationFacade.authenticator.validator,
+      authenticationFacade.subject(),
+      new DataServiceWalletsApiClientV1('mock'),
+    );
+
+    const delegateTokenProviderSpy = jest.spyOn(defaultTokenProvider, 'get');
+    return { cachedTokenProvider, delegateTokenProviderSpy };
+  }
+
+  async function getTokensConcurrently(
+    cachedTokenProvider: CachedTokenProvider,
+    cycles: number,
+    concurrentGetsPerCycle: number,
+  ) {
+    const acc: Token[] = [];
+    for (let i = 0; i < cycles; i++) {
+      console.log(`Getting tokens concurrently, cycle ${i + 1}/${cycles}`);
+      const tokens = await Promise.all(
+        new Array(concurrentGetsPerCycle)
+          .fill(0)
+          .map(() => cachedTokenProvider.get()),
+      );
+      acc.push(...tokens);
+    }
+    return acc;
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5895,6 +5895,11 @@ mocha@^9.2.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+mockdate@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.5.tgz#789be686deb3149e7df2b663d2bc4392bc3284fb"
+  integrity sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ==
+
 module-definition@^3.3.1:
   version "3.4.0"
   resolved "https://registry.npmjs.org/module-definition/-/module-definition-3.4.0.tgz"


### PR DESCRIPTION
**Context**
Token is cached between rest api calls, special logic us used to ensure it's safe to use sdk concurrently

**Problem**
It was reported that token signed multiple times when expired on mobile

**Solution**
No solution, since no repro in sdk, seems like problem is located somewhere else (see the test cases)
However I've found a different bug, resulting in stale token returned from cached token provider and fixed it in this PR