### PR TITLE
[CORE-1581] feat: make upserting wallet optional

### DIFF
--- a/packages/blockchain-sdk-aptos/src/wallet-adapter/dialect-aptos-wallet-adapter-wrapper.ts
+++ b/packages/blockchain-sdk-aptos/src/wallet-adapter/dialect-aptos-wallet-adapter-wrapper.ts
@@ -8,8 +8,9 @@ import type {
 import { UnsupportedOperationError } from '@dialectlabs/sdk';
 
 export class DialectAptosWalletAdapterWrapper
-  implements DialectAptosWalletAdapter {
-  constructor(private readonly delegate: DialectAptosWalletAdapter) { }
+  implements DialectAptosWalletAdapter
+{
+  constructor(private readonly delegate: DialectAptosWalletAdapter) {}
 
   get publicKey(): PublicKey {
     if (!this.delegate.publicKey) {

--- a/packages/identity-ans/src/identity-ans.ts
+++ b/packages/identity-ans/src/identity-ans.ts
@@ -8,7 +8,7 @@ import type { Connection } from '@solana/web3.js';
 import { ANSIdentityError } from './identity-ans.error';
 
 export class ANSIdentityResolver implements IdentityResolver {
-  constructor(private readonly connection: Connection) { }
+  constructor(private readonly connection: Connection) {}
 
   get type(): string {
     return 'ANS';
@@ -19,7 +19,7 @@ export class ANSIdentityResolver implements IdentityResolver {
       const parser = new TldParser(this.connection);
       const mainDomain = await parser.getMainDomain(address);
       const domain = mainDomain.domain;
-      const tld = mainDomain.tld
+      const tld = mainDomain.tld;
       return {
         name: `${domain}${tld}`,
         address,

--- a/packages/sdk/src/internal/sdk/sdk-factory.ts
+++ b/packages/sdk/src/internal/sdk/sdk-factory.ts
@@ -45,6 +45,7 @@ import type { EncryptionKeysProvider } from '../../encryption/encryption-keys-pr
 import { DataServiceApiFactory } from '../../dialect-cloud-api/data-service-api-factory';
 import type { DataServiceApi } from '../../dialect-cloud-api/data-service-api';
 import { DataServiceWalletsApiClientV1 } from '../../dialect-cloud-api/data-service-wallets-api.v1';
+import { isBoolean } from '../../utils/typecheck';
 
 export class InternalDialectSdk<ChainSdk extends BlockchainSdk>
   implements DialectSdk<ChainSdk>
@@ -136,6 +137,7 @@ export class DialectSdkFactory<ChainSdk extends BlockchainSdk> {
     return new CachedTokenProvider(
       defaultTokenProvider,
       config.dialectCloud.tokenStore,
+      config.dialectCloud.implicitWalletCreation,
       authenticationFacade.authenticator.parser,
       authenticationFacade.authenticator.validator,
       authenticationFacade.subject(),
@@ -276,6 +278,7 @@ export class DialectSdkFactory<ChainSdk extends BlockchainSdk> {
       url: 'https://dialectapi.to',
       tokenStore: this.createTokenStore(),
       tokenLifetimeMinutes: this.createTokenLifetime(),
+      implicitWalletCreation: true,
     };
     const environment = this.config.environment;
     if (environment) {
@@ -305,6 +308,14 @@ export class DialectSdkFactory<ChainSdk extends BlockchainSdk> {
     }
     if (this.config.dialectCloud?.url) {
       baseConfig.url = this.config.dialectCloud.url;
+    }
+
+    if (
+      this.config.dialectCloud &&
+      isBoolean(this.config.dialectCloud.implicitWalletCreation)
+    ) {
+      baseConfig.implicitWalletCreation =
+        this.config.dialectCloud?.implicitWalletCreation;
     }
     return baseConfig;
   }

--- a/packages/sdk/src/sdk/sdk.interface.ts
+++ b/packages/sdk/src/sdk/sdk.interface.ts
@@ -76,6 +76,7 @@ export interface DialectCloudConfigProps {
   url?: string;
   tokenStore?: TokenStoreType | TokenStore;
   tokenLifetimeMinutes?: number;
+  implicitWalletCreation?: boolean;
 }
 
 export type DialectCloudEnvironment =
@@ -105,6 +106,7 @@ export interface DialectCloudConfig extends DialectCloudConfigProps {
   url: string;
   tokenStore: TokenStore;
   tokenLifetimeMinutes: number;
+  implicitWalletCreation: boolean;
 }
 
 export interface IdentityConfig extends IdentityConfigProps {

--- a/packages/sdk/src/utils/typecheck.ts
+++ b/packages/sdk/src/utils/typecheck.ts
@@ -1,0 +1,3 @@
+export const isBoolean = (value: unknown): value is boolean => {
+  return typeof value === 'boolean';
+};

--- a/packages/sdk/tests/auth/cached-token-provider.spec.ts
+++ b/packages/sdk/tests/auth/cached-token-provider.spec.ts
@@ -124,6 +124,7 @@ describe('Cached token provider test', () => {
     const cachedTokenProvider = new CachedTokenProvider(
       defaultTokenProvider,
       TokenStore.createInMemory(),
+      true,
       authenticationFacade.authenticator.parser,
       authenticationFacade.authenticator.validator,
       authenticationFacade.subject(),


### PR DESCRIPTION
# Description
By default, we have behavior when sdk upserts a wallet after creating the token. This is the bottleneck in dial-app while we are creating a new user because the upsert wallet endpoint (`api/v1/wallets/me`) invokes with `x-client-name: dialect-sdk`. For example, when we want to handle created user from the dial-app we won't be able to do that, because the user will be created according to `dialect-sdk` HTTP headers context in a request